### PR TITLE
Add DANGEROUSLY_RUN_COMMANDS_ON_HOST env var

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -19,7 +19,7 @@ import { homedir } from "os";
 import { join } from "path";
 import type { StoredEmail } from "./email-store.js";
 import * as log from "./log.js";
-import { createExecutor, type DockerConfig } from "./sandbox.js";
+import { createExecutor, type SandboxConfig } from "./sandbox.js";
 import { createMomTools, setUploadFunction } from "./tools/index.js";
 
 // Hardcoded model for now
@@ -90,8 +90,14 @@ function buildSystemPrompt(
 	triggerPhrase: string,
 	fromAddress: string,
 	triggered: boolean,
+	sandboxType: "host" | "docker",
 ): string {
-	const envDescription = `You are running inside a Docker container (Alpine Linux).
+	const envDescription = sandboxType === "host"
+		? `You are running commands directly on the host machine.
+- Bash working directory: ${workspacePath}
+- You have full access to the host system
+- Your changes persist across sessions`
+		: `You are running inside a Docker container (Alpine Linux).
 - Bash working directory: / (use cd or absolute paths)
 - Install tools with: apk add <package>
 - Your changes persist across sessions`;
@@ -309,12 +315,12 @@ function formatEmailForPrompt(email: StoredEmail, direction: "received" | "sent"
  * Creates a fresh session, processes the email, and returns the reply.
  */
 export async function runAgent(
-	dockerConfig: DockerConfig,
+	sandboxConfig: SandboxConfig,
 	workingDir: string,
 	context: AgentContext,
 	triggerPhrase: string,
 ): Promise<AgentRunResult> {
-	const executor = createExecutor(dockerConfig);
+	const executor = createExecutor(sandboxConfig);
 	const workspacePath = executor.getWorkspacePath(workingDir);
 
 	// Create tools
@@ -332,7 +338,7 @@ export async function runAgent(
 	const memory = getMemory(workingDir);
 	const skills = loadSkills(workingDir, workspacePath);
 	const triggered = context.triggeredEmail.triggered;
-	const systemPrompt = buildSystemPrompt(workspacePath, memory, skills, triggerPhrase, context.fromAddress, triggered);
+	const systemPrompt = buildSystemPrompt(workspacePath, memory, skills, triggerPhrase, context.fromAddress, triggered, sandboxConfig.type);
 
 	// Create session infrastructure
 	const sessionsDir = join(workingDir, "sessions");

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,7 +10,7 @@ import { createEventsWatcher } from "./events.js";
 import * as log from "./log.js";
 import { sendEmail, validateMailgunCredentials, type MailgunConfig } from "./mailgun.js";
 import { ProcessingQueue } from "./queue.js";
-import { parseContainerArg, type DockerConfig, validateSandbox } from "./sandbox.js";
+import { parseContainerArg, type SandboxConfig, validateSandbox } from "./sandbox.js";
 
 // ============================================================================
 // Config
@@ -23,10 +23,11 @@ const MAILGUN_SIGNING_KEY = process.env.MAILGUN_SIGNING_KEY;
 const WEBHOOK_PORT = parseInt(process.env.WEBHOOK_PORT || "3000", 10);
 const TRIGGER_PHRASE = process.env.TRIGGER_PHRASE || "@Claude";
 const ALLOWED_USER_EMAIL = process.env.ALLOWED_USER_EMAIL;
+const DANGEROUSLY_RUN_COMMANDS_ON_HOST = process.env.DANGEROUSLY_RUN_COMMANDS_ON_HOST === "true";
 
 interface ParsedArgs {
 	workingDir?: string;
-	docker: DockerConfig;
+	containerName?: string;
 }
 
 function parseArgs(): ParsedArgs {
@@ -47,7 +48,7 @@ function parseArgs(): ParsedArgs {
 
 	return {
 		workingDir: workingDir ? resolve(workingDir) : undefined,
-		docker: parseContainerArg(containerName),
+		containerName,
 	};
 }
 
@@ -58,7 +59,18 @@ if (!parsedArgs.workingDir) {
 	process.exit(1);
 }
 
-const { workingDir, docker } = { workingDir: parsedArgs.workingDir, docker: parsedArgs.docker };
+const workingDir = parsedArgs.workingDir;
+
+// Determine sandbox config
+let sandbox: SandboxConfig;
+if (DANGEROUSLY_RUN_COMMANDS_ON_HOST) {
+	console.warn("WARNING: DANGEROUSLY_RUN_COMMANDS_ON_HOST is enabled. Commands will run directly on the host machine.");
+	sandbox = { type: "host" };
+} else {
+	const docker = parseContainerArg(parsedArgs.containerName);
+	await validateSandbox(docker, workingDir);
+	sandbox = { type: "docker", container: docker.container };
+}
 
 if (!MAILGUN_API_KEY || !MAILGUN_DOMAIN || !MAILGUN_FROM_ADDRESS) {
 	console.error("Missing env: MAILGUN_API_KEY, MAILGUN_DOMAIN, MAILGUN_FROM_ADDRESS");
@@ -68,8 +80,6 @@ if (!MAILGUN_API_KEY || !MAILGUN_DOMAIN || !MAILGUN_FROM_ADDRESS) {
 const mailgunApiKey: string = MAILGUN_API_KEY;
 const mailgunDomain: string = MAILGUN_DOMAIN;
 const mailgunFromAddress: string = MAILGUN_FROM_ADDRESS;
-
-await validateSandbox(docker, workingDir);
 
 // ============================================================================
 // Setup
@@ -83,7 +93,8 @@ const mailgunConfig: MailgunConfig = {
 
 const emailStore = new EmailStore(workingDir);
 
-log.logStartup(workingDir, `docker:${docker.container}`);
+const sandboxLabel = sandbox.type === "host" ? "host (DANGEROUS)" : `docker:${sandbox.container}`;
+log.logStartup(workingDir, sandboxLabel);
 
 // Validate Mailgun credentials before starting
 try {
@@ -115,7 +126,7 @@ const queue = new ProcessingQueue(async (emailId: string) => {
 	const recentEmails = emailStore.getMany(recentIds);
 
 	try {
-		const result = await runAgent(docker, workingDir, {
+		const result = await runAgent(sandbox, workingDir, {
 			triggeredEmail: email,
 			recentEmails,
 			fromAddress: mailgunFromAddress,

--- a/src/sandbox.ts
+++ b/src/sandbox.ts
@@ -6,6 +6,10 @@ export interface DockerConfig {
 	container: string;
 }
 
+export type SandboxConfig =
+	| { type: "host" }
+	| { type: "docker"; container: string };
+
 export function parseContainerArg(value: string | undefined): DockerConfig {
 	return { container: value || DEFAULT_CONTAINER };
 }
@@ -81,9 +85,13 @@ function execSimple(cmd: string, args: string[]): Promise<string> {
 }
 
 /**
- * Create an executor that runs commands in a Docker container
+ * Create an executor based on sandbox config.
+ * Returns a HostExecutor for host mode, DockerExecutor for docker mode.
  */
-export function createExecutor(config: DockerConfig): Executor {
+export function createExecutor(config: SandboxConfig): Executor {
+	if (config.type === "host") {
+		return new HostExecutor();
+	}
 	return new DockerExecutor(config.container);
 }
 


### PR DESCRIPTION
## Summary
- Adds `DANGEROUSLY_RUN_COMMANDS_ON_HOST` env var (defaults to `false`) that allows commands to run directly on the host machine instead of in a Docker container
- When enabled, skips Docker validation and uses the existing `HostExecutor` class (was dead code)
- Updates the agent system prompt to describe the correct execution environment (host vs Docker)

This is useful for cloud-based coding agents (e.g. Claude Code on the web) that already run in isolated containers, where adding a Docker layer is redundant.

Closes #6

## Test plan
- [ ] Default behavior (no env var set): should still require Docker, same as before
- [ ] With `DANGEROUSLY_RUN_COMMANDS_ON_HOST=true`: should skip Docker validation, log a warning, and execute commands on the host
- [ ] Verify startup log shows `host (DANGEROUS)` vs `docker:<name>` accordingly

🤖 Generated with [Claude Code](https://claude.com/claude-code)